### PR TITLE
Feature/optional user to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ This pipeline will:
           "WorkspaceId": "<workspace-id>",
           "Key": "<key>",
           "LogPrompt": true,
-          "LogResponse": false
+          "LogResponse": false,
+          "LogClient": true
         }
       }
     ],

--- a/samples/consumer-aad-with-local-token-rate-limiting/SampleTwo.csproj
+++ b/samples/consumer-aad-with-local-token-rate-limiting/SampleTwo.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="AICentral" Version="0.15.0-pullrequest0084-0003" />
       <PackageReference Include="AICentral.Logging.AzureMonitor" Version="0.13.0" />
-      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/prioritised-endpoint-with-fallback-and-streaming-quota-logging/SampleOne.csproj
+++ b/samples/prioritised-endpoint-with-fallback-and-streaming-quota-logging/SampleOne.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="AICentral" Version="0.15.0-pullrequest0084-0003" />
       <PackageReference Include="AICentral.Logging.AzureMonitor" Version="0.13.0" />
-      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLogger.cs
+++ b/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLogger.cs
@@ -10,17 +10,24 @@ public class AzureMonitorLogger : IPipelineStep
     private readonly string _workspaceId;
     private readonly bool _logPrompt;
     private readonly bool _logResponse;
+    private readonly bool _logClient;
 
-    public AzureMonitorLogger(ILogger serilogAzureLogAnalyticsLogger, string workspaceId, bool logPrompt, bool logResponse)
+    public AzureMonitorLogger(
+        ILogger serilogAzureLogAnalyticsLogger,
+        string workspaceId,
+        bool logPrompt,
+        bool logResponse,
+        bool logClient)
     {
         _serilogAzureLogAnalyticsLogger = serilogAzureLogAnalyticsLogger;
         _workspaceId = workspaceId;
         _logPrompt = logPrompt;
         _logResponse = logResponse;
+        _logClient = logClient;
     }
-    
+
     public async Task<AICentralResponse> Handle(
-        HttpContext context, 
+        HttpContext context,
         IncomingCallDetails aiCallInformation,
         NextPipelineStep next,
         CancellationToken cancellationToken)
@@ -28,11 +35,14 @@ public class AzureMonitorLogger : IPipelineStep
         var result = await next(context, aiCallInformation, cancellationToken);
 
         _serilogAzureLogAnalyticsLogger.Information(
-            "AzureOpenAI call. ClientIP:{ClientIP} Host:{OpenAIHost}. Type:{CallType}. StreamedResponse:{Streamed}. Deployment:{Deployment} Model:{Model}. Prompt:{Prompt}. Response:{Response}. Estimated Prompt Tokens:{EstimatedPromptTokens}. Estimated Completion Tokens:{EstimatedCompletionTokens}. Prompt Tokens:{PromptTokens}. Completion Tokens:{CompletionTokens}. Total Tokens:{TotalTokens}. Duration:{Duration}",
+            "AzureOpenAI call. ClientIP:{ClientIP}. Client Name:{ClientName}. Host:{OpenAIHost}. Type:{CallType}. StreamedResponse:{Streamed}. Deployment:{Deployment} Model:{Model}. Prompt:{Prompt}. Response:{Response}. Estimated Prompt Tokens:{EstimatedPromptTokens}. Estimated Completion Tokens:{EstimatedCompletionTokens}. Prompt Tokens:{PromptTokens}. Completion Tokens:{CompletionTokens}. Total Tokens:{TotalTokens}. Duration:{Duration}",
             result.DownstreamUsageInformation.RemoteIpAddress,
+            _logClient ? context.User.Identity?.Name ?? string.Empty : "**redacted**",
             result.DownstreamUsageInformation.OpenAIHost,
             result.DownstreamUsageInformation.CallType.ToString(),
-            result.DownstreamUsageInformation.StreamingResponse.HasValue ? result.DownstreamUsageInformation.StreamingResponse : string.Empty,
+            result.DownstreamUsageInformation.StreamingResponse.HasValue
+                ? result.DownstreamUsageInformation.StreamingResponse
+                : string.Empty,
             result.DownstreamUsageInformation.DeploymentName,
             result.DownstreamUsageInformation.ModelName,
             _logPrompt ? result.DownstreamUsageInformation.Prompt : "**redacted**",
@@ -47,7 +57,8 @@ public class AzureMonitorLogger : IPipelineStep
         return result;
     }
 
-    public Task BuildResponseHeaders(HttpContext context, HttpResponseMessage rawResponse, Dictionary<string, StringValues> rawHeaders)
+    public Task BuildResponseHeaders(HttpContext context, HttpResponseMessage rawResponse,
+        Dictionary<string, StringValues> rawHeaders)
     {
         return Task.CompletedTask;
     }

--- a/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLoggerFactory.cs
+++ b/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLoggerFactory.cs
@@ -17,7 +17,8 @@ public class AzureMonitorLoggerFactory : IPipelineStepFactory
         string workspaceId,
         string key,
         bool logPrompt,
-        bool logResponse)
+        bool logResponse,
+        bool logClient)
     {
         _workspaceId = workspaceId;
         _logPrompt = logPrompt;
@@ -26,14 +27,14 @@ public class AzureMonitorLoggerFactory : IPipelineStepFactory
                     _workspaceId,
                     key,
                     logName: "AILogs"
-                ).CreateLogger(), _workspaceId, _logPrompt, logResponse
+                ).CreateLogger(), _workspaceId, _logPrompt, logResponse, logClient
         ));
     }
 
     public static string ConfigName => "AzureMonitorLogger";
 
     public static IPipelineStepFactory BuildFromConfig(
-        ILogger logger, 
+        ILogger logger,
         TypeAndNameConfig config)
     {
         var properties = config.TypedProperties<AzureMonitorLoggingConfig>()!;
@@ -43,7 +44,8 @@ public class AzureMonitorLoggerFactory : IPipelineStepFactory
             Guard.NotNull(properties.WorkspaceId, nameof(properties.WorkspaceId)),
             Guard.NotNull(properties.Key, nameof(properties.Key)),
             Guard.NotNull(properties.LogPrompt, nameof(properties.LogPrompt))!.Value,
-            Guard.NotNull(properties.LogResponse, nameof(properties.LogResponse))!.Value
+            Guard.NotNull(properties.LogResponse, nameof(properties.LogResponse))!.Value,
+            properties.LogClient.GetValueOrDefault()
         );
     }
 
@@ -55,7 +57,7 @@ public class AzureMonitorLoggerFactory : IPipelineStepFactory
     public void RegisterServices(IServiceCollection services)
     {
     }
-    
+
     public object WriteDebug()
     {
         return new

--- a/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLoggingConfig.cs
+++ b/src/AICentral.Logging.AzureMonitor/AzureMonitorLogging/AzureMonitorLoggingConfig.cs
@@ -6,4 +6,5 @@ public class AzureMonitorLoggingConfig
     public string? Key { get; init; }
     public bool? LogPrompt { get; init; }
     public bool? LogResponse { get; init; }
+    public bool? LogClient { get; init; }
 }

--- a/src/AICentral/AICentral.csproj
+++ b/src/AICentral/AICentral.csproj
@@ -19,11 +19,11 @@
         <PackageReference Include="AICentral.Core" Version="0.15.0-pullrequest0084-0003" />
         <PackageReference Include="Azure.Identity" Version="1.10.4" />
         <PackageReference Include="Microsoft.AspNetCore.RateLimiting" Version="7.0.0-rc.2.22476.2"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Identity.Web" Version="2.16.0" />
-        <PackageReference Include="Polly" Version="8.2.0" />
-        <PackageReference Include="SharpToken" Version="1.2.14" />
-        <PackageReference Include="System.Text.Json" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Identity.Web" Version="2.17.0" />
+        <PackageReference Include="Polly" Version="8.3.0" />
+        <PackageReference Include="SharpToken" Version="1.2.17" />
+        <PackageReference Include="System.Text.Json" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AICentral/Configuration/AICentralPipelineAssembler.cs
+++ b/src/AICentral/Configuration/AICentralPipelineAssembler.cs
@@ -104,7 +104,11 @@ public class AICentralPipelineAssembler
                         throw new ArgumentException($"No EndpointSelector for pipeline {pipelineConfig.Name}"))
                         ? _endpointSelectors[pipelineConfig.EndpointSelector ?? string.Empty]
                         : throw new ArgumentException(
-                            $"Cannot find EndpointSelector {pipelineConfig.EndpointSelector}"));
+                            $"Cannot find EndpointSelector {pipelineConfig.EndpointSelector}"),
+                    pipelineConfig.OpenTelemetryConfig ?? new OTelConfig()
+                    {
+                        AddClientNameTag = false
+                    });
 
                 startupLogger.LogInformation("Configured Pipeline {Name} on Host {Host}", pipelineConfig.Name,
                     pipelineConfig.Host);

--- a/src/AICentral/OTelConfig.cs
+++ b/src/AICentral/OTelConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace AICentral;
+
+public class OTelConfig
+{
+    public bool? AddClientNameTag { get; init; }
+}

--- a/src/AICentral/PipelineConfig.cs
+++ b/src/AICentral/PipelineConfig.cs
@@ -29,4 +29,10 @@ public class PipelineConfig
     /// Array of step-names to execute in order
     /// </summary>
     public string[]? Steps { get; init; }
+
+    public OTelConfig? OpenTelemetryConfig
+    {
+        get;
+        init;
+    }
 }

--- a/src/AICentral/readme.md
+++ b/src/AICentral/readme.md
@@ -86,7 +86,7 @@ This pipeline will:
 - Protect the front-end by requiring an AAD token issued for your own AAD application
 - Put a local Asp.Net core rate-limiting policy over the endpoint
 - Add logging to Azure monitor
-    - Logs quota, client caller information, and in this case the Prompt but not the response.
+    - Logs quota, client caller information (IP and identity name), and in this case the Prompt but not the response.
 - Publish the client-name as a tag in Open Telemetry
 
 ```json
@@ -172,7 +172,8 @@ This pipeline will:
           "WorkspaceId": "<workspace-id>",
           "Key": "<key>",
           "LogPrompt": true,
-          "LogResponse": false
+          "LogResponse": false,
+          "LogClient": true
         }
       },
       {

--- a/src/AICentral/readme.md
+++ b/src/AICentral/readme.md
@@ -23,6 +23,7 @@ This sample produces a AI-Central proxy that
 - Listens on a hostname of your choosing
 - Proxies directly through to a back-end Open AI server
 - Can be accessed using standard SDKs
+- Outputs open-telemetry metrics to capture usage information
 
 ```json
 {
@@ -68,6 +69,7 @@ This sample produces a AI-Central proxy that
         "Host": "mypipeline.mydomain.com",
         "EndpointSelector": "default",
         "AuthProvider": "apikey"
+        
       }
     ]
   }
@@ -85,6 +87,7 @@ This pipeline will:
 - Put a local Asp.Net core rate-limiting policy over the endpoint
 - Add logging to Azure monitor
     - Logs quota, client caller information, and in this case the Prompt but not the response.
+- Publish the client-name as a tag in Open Telemetry
 
 ```json
 {
@@ -97,7 +100,7 @@ This pipeline will:
           "LanguageEndpoint": "https://<my-ai>.openai.azure.com",
           "AuthenticationType": "Entra|EntraPassThrough|ApiKey",
           "MaxConcurrency": 10
-        }~~~~
+        }
       },
       {
         "Type": "OpenAIEndpoint",
@@ -190,7 +193,10 @@ This pipeline will:
           "window-rate-limiter",
           "bulk-head",
           "azure-monitor-logger"
-        ]
+        ],
+        "OpenTelemetryConfig": {
+          "AddClientNameTag": true
+        }
       }
     ]
   }

--- a/src/AICentralTests/AICentralTests.csproj
+++ b/src/AICentralTests/AICentralTests.csproj
@@ -13,16 +13,16 @@
         <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
         <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.2" />
         <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="Verify.Xunit" Version="22.8.0" />
-        <PackageReference Include="xunit" Version="2.6.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+        <PackageReference Include="Verify.Xunit" Version="23.2.1" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/AICentralTests/Assistants/open_ai_assistants.cs
+++ b/src/AICentralTests/Assistants/open_ai_assistants.cs
@@ -7,7 +7,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.Assistants;
 
-[UsesVerify]
 public class open_ai_assistants : IClassFixture<TestWebApplicationFactory<Program>>, IDisposable
 {
     private readonly TestWebApplicationFactory<Program> _factory;

--- a/src/AICentralTests/Configuration/the_pipeline_config.cs
+++ b/src/AICentralTests/Configuration/the_pipeline_config.cs
@@ -11,7 +11,6 @@ using Newtonsoft.Json;
 
 namespace AICentralTests.Configuration;
 
-[UsesVerify]
 public class the_pipeline_config
 {
     [Fact]

--- a/src/AICentralTests/Configuration/the_pipeline_config.supports_minimal_setup.verified.txt
+++ b/src/AICentralTests/Configuration/the_pipeline_config.supports_minimal_setup.verified.txt
@@ -18,6 +18,9 @@
           }
         }
       ]
+    },
+    OpenTelemetryConfig: {
+      AddClientNameTag: false
     }
   }
 ]

--- a/src/AICentralTests/EndpointSelectors/the_endpoint_selector.can_contain_an_endpoint_selector.verified.txt
+++ b/src/AICentralTests/EndpointSelectors/the_endpoint_selector.can_contain_an_endpoint_selector.verified.txt
@@ -23,6 +23,9 @@
           ]
         }
       ]
+    },
+    OpenTelemetryConfig: {
+      AddClientNameTag: false
     }
   }
 ]

--- a/src/AICentralTests/EndpointSelectors/the_endpoint_selector.cs
+++ b/src/AICentralTests/EndpointSelectors/the_endpoint_selector.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.EndpointSelectors;
 
-[UsesVerify]
 public class the_endpoint_selector : IClassFixture<TestWebApplicationFactory<Program>>
 {
     private readonly TestWebApplicationFactory<Program> _factory;

--- a/src/AICentralTests/Endpoints/the_azure_openai_pipeline.cs
+++ b/src/AICentralTests/Endpoints/the_azure_openai_pipeline.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.Endpoints;
 
-[UsesVerify]
 public class the_azure_openai_pipeline : IClassFixture<TestWebApplicationFactory<Program>>, IDisposable
 {
     private readonly TestWebApplicationFactory<Program> _factory;

--- a/src/AICentralTests/Endpoints/the_openai_dispatcher.cs
+++ b/src/AICentralTests/Endpoints/the_openai_dispatcher.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.Endpoints;
 
-[UsesVerify]
 public class the_openai_dispatcher : IClassFixture<TestWebApplicationFactory<Program>>, IDisposable
 {
     private readonly TestWebApplicationFactory<Program> _factory;

--- a/src/AICentralTests/Endpoints/the_pipelines_that_read_the_input_stream.cs
+++ b/src/AICentralTests/Endpoints/the_pipelines_that_read_the_input_stream.cs
@@ -8,7 +8,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.Endpoints;
 
-[UsesVerify]
 public class the_pipelines_that_read_the_input_stream : IClassFixture<TestWebApplicationFactory<Program>>, IDisposable
 {
     public void Dispose()

--- a/src/AICentralTests/Endpoints/the_streaming_endpoints.cs
+++ b/src/AICentralTests/Endpoints/the_streaming_endpoints.cs
@@ -9,7 +9,6 @@ using Xunit.Abstractions;
 
 namespace AICentralTests.Endpoints;
 
-[UsesVerify]
 public class the_streaming_endpoints : IClassFixture<TestWebApplicationFactory<Program>>, IDisposable
 {
     private readonly TestWebApplicationFactory<Program> _factory;

--- a/src/AICentralWeb/AICentralWeb.csproj
+++ b/src/AICentralWeb/AICentralWeb.csproj
@@ -17,11 +17,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+      <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
       <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
-      <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+      <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added optional callee identity name to Azure Monitor, and to the OTel metrics.
This will support features like charge-back without requiring full logging of all responses.