### PR TITLE
Adding model mapping back to Azure Open AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See [advanced-otel](./docs/advanced-otel.md) for dashboard inspiration!
 This pipeline will:
 
 - Present an Azure Open AI, and an Open AI downstream as a single upstream endpoint
+  - maps the incoming deployment Name "GPT35Turbo0613" to the downstream Azure Open AI deployment "MyGptModel"
   - maps incoming Azure Open AI deployments to Open AI models
 - Present it as an Azure Open AI style endpoint
 - Protect the front-end by requiring an AAD token issued for your own AAD application
@@ -176,7 +177,10 @@ This pipeline will:
         "Name": "openai-priority",
         "Properties": {
           "LanguageEndpoint": "https://<my-ai>.openai.azure.com",
-          "AuthenticationType": "Entra|EntraPassThrough|ApiKey"
+          "AuthenticationType": "Entra|EntraPassThrough|ApiKey",
+          "ModelMappings": {
+            "Gpt35Turbo0613": "MyGptModel"
+          }
         }
       },
       {

--- a/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIDownstreamEndpointAdapterFactory.cs
+++ b/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIDownstreamEndpointAdapterFactory.cs
@@ -89,6 +89,8 @@ public class AzureOpenAIDownstreamEndpointAdapterFactory : IDownstreamEndpointAd
         {
             Type = "AzureOpenAI",
             Url = _languageUrl,
+            Mappings = _modelMappings,
+            AssistantMappings = _assistantMappings,
             Auth = _authHandler.WriteDebug()
         };
     }

--- a/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIDownstreamEndpointAdapterFactory.cs
+++ b/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIDownstreamEndpointAdapterFactory.cs
@@ -8,6 +8,7 @@ public class AzureOpenAIDownstreamEndpointAdapterFactory : IDownstreamEndpointAd
     private readonly string _endpointName;
     private readonly string _languageUrl;
     private readonly Dictionary<string, string> _assistantMappings;
+    private readonly Dictionary<string, string> _modelMappings;
     private readonly string _id;
     private readonly int? _maxConcurrency;
     
@@ -16,6 +17,7 @@ public class AzureOpenAIDownstreamEndpointAdapterFactory : IDownstreamEndpointAd
         string languageUrl,
         string authenticationType,
         string? authenticationKey,
+        Dictionary<string, string> modelMappings,
         Dictionary<string, string> assistantMappings,
         int? maxConcurrency = null)
     {
@@ -23,6 +25,7 @@ public class AzureOpenAIDownstreamEndpointAdapterFactory : IDownstreamEndpointAd
 
         _endpointName = endpointName;
         _languageUrl = languageUrl;
+        _modelMappings = modelMappings;
         _assistantMappings = assistantMappings;
         _maxConcurrency = maxConcurrency;
 
@@ -70,13 +73,14 @@ public class AzureOpenAIDownstreamEndpointAdapterFactory : IDownstreamEndpointAd
             Guard.NotNull(properties.LanguageEndpoint, nameof(properties.LanguageEndpoint)),
             authenticationType,
             properties.ApiKey,
+            properties.ModelMappings ?? new Dictionary<string, string>(),
             properties.AssistantMappings ?? new Dictionary<string, string>(),
             properties.MaxConcurrency);
     }
 
     public IDownstreamEndpointAdapter Build()
     {
-        return new AzureOpenAIDownstreamEndpointAdapter(_id, _languageUrl, _endpointName, _assistantMappings, _authHandler);
+        return new AzureOpenAIDownstreamEndpointAdapter(_id, _languageUrl, _endpointName, _modelMappings, _assistantMappings, _authHandler);
     }
 
     public object WriteDebug()

--- a/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIEndpointPropertiesConfig.cs
+++ b/src/AICentral/Endpoints/AzureOpenAI/AzureOpenAIEndpointPropertiesConfig.cs
@@ -5,6 +5,7 @@ public class AzureOpenAIEndpointPropertiesConfig
     public string? LanguageEndpoint { get; init; }
     public string? AuthenticationType { get; init; }
     public string? ApiKey { get; set; }
+    public Dictionary<string, string>? ModelMappings { get; init; }
     public Dictionary<string, string>? AssistantMappings { get; set; }
     public int? MaxConcurrency { get; set; }
 }

--- a/src/AICentral/Endpoints/DownstreamEndpointDispatcher.cs
+++ b/src/AICentral/Endpoints/DownstreamEndpointDispatcher.cs
@@ -101,10 +101,7 @@ internal class DownstreamEndpointDispatcher : IEndpointDispatcher
             }
             else
             {
-                if (context.Response.Headers.TryGetValue("x-aicentral-failed-servers", out var header))
-                {
-                    context.Response.Headers.Remove("x-aicentral-failed-servers");
-                }
+                context.Response.Headers.Remove("x-aicentral-failed-servers", out var header);
 
                 context.Response.Headers.TryAdd("x-aicentral-failed-servers",
                     StringValues.Concat(header, _iaiCentralDownstreamEndpointAdapter.BaseUrl.Host));

--- a/src/AICentral/Endpoints/OpenAI/OpenAIDownstreamEndpointAdapter.cs
+++ b/src/AICentral/Endpoints/OpenAI/OpenAIDownstreamEndpointAdapter.cs
@@ -45,7 +45,7 @@ public class OpenAIDownstreamEndpointAdapter : OpenAILikeDownstreamEndpointAdapt
         return false;
     }
 
-    protected override string BuildUri(HttpContext context, IncomingCallDetails aiCallInformation, string? incomingAssistantName, string? mappedAssistantName)
+    protected override string BuildUri(HttpContext context, IncomingCallDetails aiCallInformation, string? incomingAssistantName, string? mappedAssistantName, string? incomingModelName, string? mappedModelName)
     {
         var pathPiece = aiCallInformation.AICallType switch
         {
@@ -80,4 +80,10 @@ public class OpenAIDownstreamEndpointAdapter : OpenAILikeDownstreamEndpointAdapt
 
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Open AI always takes a model name in the body, so we need to ensure it is there.
+    /// </summary>
+    /// <returns></returns>
+    protected override bool ForceAddModelNameToBody() => true;
 }

--- a/src/AICentral/Endpoints/OpenAILikeDownstreamEndpointAdapter.cs
+++ b/src/AICentral/Endpoints/OpenAILikeDownstreamEndpointAdapter.cs
@@ -30,6 +30,8 @@ public abstract class OpenAILikeDownstreamEndpointAdapter : IDownstreamEndpointA
     public async Task<Either<HttpRequestMessage, IResult>> BuildRequest(IncomingCallDetails callInformation,
         HttpContext context)
     {
+        var logger = context.RequestServices.GetRequiredService<ILogger<OpenAILikeDownstreamEndpointAdapter>>();
+        
         var incomingModelName = callInformation.IncomingModelName;
         _modelMappings.TryGetValue(incomingModelName ?? string.Empty, out var mappedModelName);
 
@@ -51,6 +53,15 @@ public abstract class OpenAILikeDownstreamEndpointAdapter : IDownstreamEndpointA
 
         try
         {
+            if (incomingModelName != mappedModelName)
+            {
+                logger.LogDebug("Detected mapped model - Mapping incoming model {IncomingModel} to {MappedModel}", incomingModelName, mappedModelName);
+            }
+            if (incomingAssistantName != mappedAssistantName)
+            {
+                logger.LogDebug("Detected assistant call - Mapping incoming assistant {IncomingAssistant} to {MappedAssistant}", incomingAssistantName, mappedAssistantName);
+            }
+            
             return new Either<HttpRequestMessage, IResult>(
                 await BuildNewRequest(
                     context,

--- a/src/AICentral/readme.md
+++ b/src/AICentral/readme.md
@@ -85,7 +85,8 @@ This sample produces a AI-Central proxy that
 This pipeline will:
 
 - Present an Azure Open AI, and an Open AI downstream as a single upstream endpoint
-    - maps incoming Azure Open AI deployments to Open AI models
+  - maps the incoming deployment Name "GPT35Turbo0613" to the downstream Azure Open AI deployment "MyGptModel"
+  - maps incoming Azure Open AI deployments to Open AI models
 - Present it as an Azure Open AI style endpoint
 - Protect the front-end by requiring an AAD token issued for your own AAD application
 - Put a local Asp.Net core rate-limiting policy over the endpoint
@@ -104,7 +105,10 @@ This pipeline will:
         "Properties": {
           "LanguageEndpoint": "https://<my-ai>.openai.azure.com",
           "AuthenticationType": "Entra|EntraPassThrough|ApiKey",
-          "MaxConcurrency": 10
+          "MaxConcurrency": 10,
+          "ModelMappings": {
+            "Gpt35Turbo0613": "MyGptModel"
+          }
         }
       },
       {

--- a/src/AICentralTests/Endpoints/the_azure_openai_pipeline.can_map_models.verified.txt
+++ b/src/AICentralTests/Endpoints/the_azure_openai_pipeline.can_map_models.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  Requests:
+[
+  {
+    "Uri": "/openai/deployments/mapped/chat/completions?api-version=2024-02-15-preview",
+    "Method": "POST",
+    "Headers": {
+      "Accept": "application/json",
+      "x-ms-return-client-request-id": "true",
+      "api-key": "ignore-fake-key-hr987345"
+    },
+    "ContentType": "application/json",
+    "Content": "{\"messages\":[{\"content\":[{\"text\":\"I am some text\",\"type\":\"text\"}],\"role\":\"user\"}],\"model\":\"mapped\"}"
+  }
+],
+  Response: {
+    Headers: [
+      {
+        Name: x-ratelimit-remaining-requests,
+        Value: 12
+      },
+      {
+        Name: x-ratelimit-remaining-tokens,
+        Value: 234
+      },
+      {
+        Name: Content-Type,
+        Value: application/json
+      }
+    ]
+  },
+  ResponseMetadata: {
+    InternalEndpointName: Guid_1,
+    OpenAIHost: Guid_1,
+    ModelName: gpt-35-turbo,
+    DeploymentName: random,
+    Client: ,
+    StreamingResponse: false,
+    Prompt: I am some text ,
+    Response:
+Choice 0
+
+Yes, other Azure AI services also support customer managed keys. Azure AI services offer multiple options for customers to manage keys, such as using Azure Key Vault, customer-managed keys in Azure Key Vault or customer-managed keys through Azure Storage service. This helps customers ensure that their data is secure and access to their services is controlled.
+,
+    KnownTokens: {
+      Item1: 58,
+      Item2: 68,
+      Item3: 126
+    },
+    ResponseMetadata: {
+      SanitisedHeaders: {
+        x-ratelimit-remaining-requests: [
+          12
+        ],
+        x-ratelimit-remaining-tokens: [
+          234
+        ]
+      },
+      RemainingTokens: 234,
+      RemainingRequests: 12
+    },
+    RemoteIpAddress: ,
+    StartDate: DateTimeOffset_1,
+    Success: true,
+    TotalTokens: 126
+  }
+}

--- a/src/AICentralTests/Endpoints/the_azure_openai_pipeline.cs
+++ b/src/AICentralTests/Endpoints/the_azure_openai_pipeline.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Text;
-using AICentral;
 using AICentralTests.TestHelpers;
 using AICentralWeb;
 using Azure;
@@ -380,6 +379,37 @@ public class the_azure_openai_pipeline : IClassFixture<TestWebApplicationFactory
                 DeploymentName = "random"
             });
 
+        await Verify(_factory.VerifyRequestsAndResponses(result.GetRawResponse(), true));
+    }
+
+    [Fact]
+    public async Task can_map_models()
+    {
+        _factory.SeedChatCompletions(AICentralFakeResponses.Endpoint200, "mapped",
+            () => Task.FromResult(AICentralFakeResponses.FakeChatCompletionsResponse()));
+
+        var client = new OpenAIClient(
+            new Uri("http://azure-openai-to-azure-with-mapped-models.localtest.me"),
+            new AzureKeyCredential("ignore"),
+            new OpenAIClientOptions()
+            {
+                Transport = new HttpClientTransport(_httpClient)
+            });
+
+        var result = await client.GetChatCompletionsAsync(
+            new ChatCompletionsOptions()
+            {
+                Messages =
+                {
+                    new ChatRequestUserMessage(
+                    [
+                        new ChatMessageTextContentItem("I am some text"),
+                    ]),
+                },
+                DeploymentName = "random"
+            });
+
+        result.GetRawResponse().Status.ShouldBe(200);
         await Verify(_factory.VerifyRequestsAndResponses(result.GetRawResponse(), true));
     }
 

--- a/src/AICentralTests/Endpoints/the_openai_dispatcher.can_proxy_a_azure_dall_e_2_request_to_openai.received.txt
+++ b/src/AICentralTests/Endpoints/the_openai_dispatcher.can_proxy_a_azure_dall_e_2_request_to_openai.received.txt
@@ -1,0 +1,24 @@
+﻿{
+  Requests:
+[
+  {
+    "Uri": "/v1/images/generations",
+    "Method": "POST",
+    "Headers": {},
+    "ContentType": "application/json",
+    "Content": "{\"prompt\":\"draw me something blue\"}"
+  }
+],
+  Response: {
+    Headers: [],
+    Content:
+{
+  "created": 1702525301,
+  "data": [
+    {
+      "url": "https://somewhere-else.com"
+    }
+  ]
+}
+  }
+}

--- a/src/AICentralTests/Endpoints/the_openai_dispatcher.will_forward_whisper_transcription_requests_to_openai_with_a_failed_endpoints.verified.txt
+++ b/src/AICentralTests/Endpoints/the_openai_dispatcher.will_forward_whisper_transcription_requests_to_openai_with_a_failed_endpoints.verified.txt
@@ -10,7 +10,7 @@
     "ContentType": "multipart/form-data",
     "Content": {
       "Type": "multipart/form-data",
-      "Length": 34058
+      "Length": 34062
     }
   }
 ],

--- a/src/AICentralTests/TestHelpers/TestAICentralPipelineBuilder.cs
+++ b/src/AICentralTests/TestHelpers/TestAICentralPipelineBuilder.cs
@@ -62,7 +62,29 @@ public class TestAICentralPipelineBuilder
             "ApiKey",
             "ignore-fake-key-hr987345",
             new Dictionary<string, string>(),
+            new Dictionary<string, string>(),
             maxConcurrencyToAllowThrough);
+
+        _endpointFactory =
+            new SingleEndpointSelectorFactory(new DownstreamEndpointDispatcherFactory(openAiEndpointDispatcherBuilder));
+        _openAiEndpointDispatcherBuilders = new[]
+            { new DownstreamEndpointDispatcherFactory(openAiEndpointDispatcherBuilder) };
+
+        return this;
+    }
+    
+    public TestAICentralPipelineBuilder WithSingleMappedEndpoint(string hostname, string model, string mappedModel)
+    {
+        var openAiEndpointDispatcherBuilder = new AzureOpenAIDownstreamEndpointAdapterFactory(
+            hostname,
+            $"https://{hostname}",
+            "ApiKey",
+            "ignore-fake-key-hr987345",
+            new Dictionary<string, string>()
+            {
+                [model] = mappedModel
+            }, 
+            new Dictionary<string, string>());
 
         _endpointFactory =
             new SingleEndpointSelectorFactory(new DownstreamEndpointDispatcherFactory(openAiEndpointDispatcherBuilder));
@@ -103,6 +125,7 @@ public class TestAICentralPipelineBuilder
                 $"https://{x.hostname}",
                 "ApiKey",
                 "ignore-fake-key-456456",
+                new Dictionary<string, string>(),
                 new Dictionary<string, string>()
                 ))).ToArray();
 
@@ -112,6 +135,7 @@ public class TestAICentralPipelineBuilder
                 $"https://{x.hostname}",
                 "ApiKey",
                 "ignore-fake-key-sdfsdf",
+                new Dictionary<string, string>(),
                 new Dictionary<string, string>()))).ToArray();
 
         _openAiEndpointDispatcherBuilders = priorityOpenAIEndpointDispatcherBuilder
@@ -134,6 +158,7 @@ public class TestAICentralPipelineBuilder
                 $"https://{x.hostname}",
                 "ApiKey",
                 "ignore-fake-key-12345678",
+                new Dictionary<string, string>(),
                 new Dictionary<string, string>()
                 {
                     [x.assistant] = x.mappedAssistant
@@ -153,6 +178,7 @@ public class TestAICentralPipelineBuilder
                 $"https://{x.hostname}",
                 "ApiKey",
                 "fake-dfjiud",
+                new Dictionary<string, string>(),
                 new Dictionary<string, string>()))).ToArray();
 
         _endpointFactory = new LowestLatencyEndpointSelectorFactory(_openAiEndpointDispatcherBuilders!);
@@ -272,6 +298,7 @@ public class TestAICentralPipelineBuilder
             $"https://{endpoint200}",
             "ApiKey",
             "bacca18e-f471-4eca-9ea3-c8ee7155dacb",
+            new Dictionary<string, string>(),
             new Dictionary<string, string>());
 
         var endpointFactory =

--- a/src/AICentralTests/TestHelpers/TestPipelines.cs
+++ b/src/AICentralTests/TestHelpers/TestPipelines.cs
@@ -58,6 +58,11 @@ public static class TestPipelines
             .WithSingleEndpoint(AICentralFakeResponses.Endpoint200)
             .Assemble("azure-openai-to-azure.localtest.me");
 
+    public static AICentralPipelineAssembler AzureOpenAIServiceWithSingleAzureOpenAIEndpointWithMappedModel() =>
+        new TestAICentralPipelineBuilder()
+            .WithSingleMappedEndpoint(AICentralFakeResponses.Endpoint200, "random", "mapped")
+            .Assemble("azure-openai-to-azure-with-mapped-models.localtest.me");
+
     public static AICentralPipelineAssembler AzureOpenAIServiceWith404Endpoint() =>
         new TestAICentralPipelineBuilder()
             .WithSingleEndpoint(AICentralFakeResponses.Endpoint404)

--- a/src/AICentralTests/TestHelpers/TestWebApplicationFactory.cs
+++ b/src/AICentralTests/TestHelpers/TestWebApplicationFactory.cs
@@ -49,7 +49,8 @@ public class TestWebApplicationFactory<TProgram> : WebApplicationFactory<TProgra
                 TestPipelines.AzureOpenAIServiceWithRandomOpenAIEndpoints(),
                 TestPipelines.AzureOpenAIServiceWithRandomOpenAIEndpointsDifferentModelMappings(),
                 TestPipelines.AzureOpenAIServiceWith404Endpoint(),
-                TestPipelines.AzureOpenAIServiceWithRandomAffinityBasedAzureOpenAIEndpoints()
+                TestPipelines.AzureOpenAIServiceWithRandomAffinityBasedAzureOpenAIEndpoints(),
+                TestPipelines.AzureOpenAIServiceWithSingleAzureOpenAIEndpointWithMappedModel(),
             };
 
             var assembler = pipelines.Aggregate(pipelines[0], (prev, current) => prev.CombineAssemblers(current));


### PR DESCRIPTION
Fixes #100 - puts model mappings back into Azure Open AI for more flexibility in standardising the north facing calls to the south facing calls.