### PR TITLE
Fix UriFormatException when data URI length greater than 65520

### DIFF
--- a/src/AICentral/AzureOpenAIDetector.cs
+++ b/src/AICentral/AzureOpenAIDetector.cs
@@ -81,10 +81,9 @@ public class AzureOpenAIDetector
                                     if (uriNode != null)
                                     {
                                         var uriString = uriNode.GetValue<string>();
-                                        var uri = new Uri(uriString);
-                                        var uriValue = uri.Scheme.StartsWith("http")
+                                        var uriValue = uriString.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                                             ? $"   image: {uriString}"
-                                            : $"   image: {uri.Scheme} data";
+                                            : "   image: data";
                                         arrayContent.AppendLine($"{uriValue}");
                                     }
                                 }

--- a/src/AICentralTests/Endpoints/sending_urls_to_openai.ai_central_can_filter_them.verified.txt
+++ b/src/AICentralTests/Endpoints/sending_urls_to_openai.ai_central_can_filter_them.verified.txt
@@ -46,7 +46,7 @@ user:
 user:
    image: http://somewherebad.com/myimage.jpeg
    image: http://somewheregood.com/myimage.jpeg
-   image: data data
+   image: data
 ,
     Response:
 Choice 0


### PR DESCRIPTION
Fixes #157 by avoiding construction of the `Uri` instance.

Minor improvement to the extracted prompt content when a data URI is present.